### PR TITLE
Implement subscription screen and tests

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -54,11 +54,11 @@ function App(): React.JSX.Element {
         <Text style={styles.subscriptionText}>Tapyn Subscription</Text>
 
         <TouchableOpacity
-          onPress={() => iapService.checkFeatureAccess('weekly_plan')}
+          onPress={() => iapService.checkFeatureAccess('tapyn')}
           style={styles.button}
         >
           <Text style={styles.buttonText}>
-            Access: {appState.entitlements.includes('tapyn') ? 'Granted' : 'Locked'}
+            tapyn (weekly): {appState.entitlements.includes('tapyn') ? 'Granted' : 'Locked'}
           </Text>
         </TouchableOpacity>
 

--- a/App.tsx
+++ b/App.tsx
@@ -1,84 +1,14 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { StyleSheet, SafeAreaView, View, Text, TouchableOpacity, ScrollView, FlatList } from 'react-native';
-import { IapticRN, IapticProduct, IapticOffer } from 'react-native-iaptic';
+import { StyleSheet, SafeAreaView, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { IapticRN } from 'react-native-iaptic';
 import { AppStateManager, initialAppState } from './src/AppState';
 import { AppService } from './src/AppService';
+import { SubscriptionScreen } from './src/SubscriptionScreen';
+import { singletons } from './src/singletons';
 
 // Persist singletons
-let appStateManagerInstance: AppStateManager | null = null;
-let iapServiceInstance: AppService | null = null;
-
-/**
- * Screen displaying custom subscription products
- */
-function SubscriptionScreen({ onClose }: { onClose: () => void }) {
-  const [subscriptions, setSubscriptions] = useState<IapticProduct[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        // Ensure products are loaded
-        // await IapticRN.loadProducts();
-        // Fetch all products, then filter for auto-renewable subscriptions
-     
-        // once you know the current user’s ID:
-        const myUserId = 'user_12345'; // e.g. from your auth context
-        await IapticRN.setApplicationUsername(myUserId);
 
 
-        const all = IapticRN.getProducts();
-        const subs = all.filter(
-          p => p.type === 'paid subscription' || 'consumable',
-        );
-        setSubscriptions(subs);
-      } catch (err) {
-        console.warn('Error loading subscription products:', err);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, []);
-
-  if (loading) {
-    return (
-      <View style={styles.loadingContainer}>
-        <Text>Loading subscriptions…</Text>
-      </View>
-    );
-  }
-
-  return (
-    <View style={styles.screenContainer}>
-      <TouchableOpacity onPress={onClose} style={styles.backButton}>
-        <Text style={styles.backText}>← Back</Text>
-      </TouchableOpacity>
-
-      <FlatList
-        data={subscriptions}
-        keyExtractor={item => item.id}
-        contentContainerStyle={styles.list}
-        renderItem={({ item }) => {
-          // Use the first available offer for each subscription
-          const offer: IapticOffer = item.offers[0];
-          return (
-            <View style={styles.card}>
-              <Text style={styles.title}>{item.title}</Text>
-              <Text style={styles.price}>{offer.localizedPrice || offer.pricingPhases[0].price}</Text>
-              <Text style={styles.detail}>{offer.pricingPhases[0].billingPeriod}</Text>
-              <TouchableOpacity
-                style={styles.button}
-                onPress={() => IapticRN.order(offer)}
-              >
-                <Text style={styles.buttonText}>Buy</Text>
-              </TouchableOpacity>
-            </View>
-          );
-        }}
-      />
-    </View>
-  );
-}
 
 /**
  * Main App component
@@ -89,11 +19,13 @@ function App(): React.JSX.Element {
 
   // Instantiate singletons once
   const appStateManager = useRef<AppStateManager>(
-    appStateManagerInstance || (appStateManagerInstance = new AppStateManager([appState, setAppState]))
+    singletons.appStateManagerInstance ||
+      (singletons.appStateManagerInstance = new AppStateManager([appState, setAppState]))
   ).current;
 
   const iapService = useRef<AppService>(
-    iapServiceInstance || (iapServiceInstance = new AppService(appStateManager))
+    singletons.iapServiceInstance ||
+      (singletons.iapServiceInstance = new AppService(appStateManager))
   ).current;
 
   // One-time setup: initialize Iaptic and fetch products
@@ -151,17 +83,6 @@ const styles = StyleSheet.create({
   button: { backgroundColor: '#007AFF', padding: 14, borderRadius: 8, alignItems: 'center' },
   subscriptionButton: { marginTop: 16, backgroundColor: '#5856D6' },
   buttonText: { color: '#fff', fontSize: 16 },
-
-  // SubscriptionScreen styles
-  screenContainer: { flex: 1, paddingTop: 40 },
-  backButton: { padding: 12 },
-  backText: { fontSize: 16, color: '#007AFF' },
-  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  list: { padding: 16 },
-  card: { backgroundColor: '#fff', borderRadius: 8, padding: 16, marginBottom: 12, shadowColor: '#000', shadowOpacity: 0.1, shadowRadius: 4 },
-  title: { fontSize: 18, fontWeight: 'bold' },
-  price: { fontSize: 16, marginVertical: 4 },
-  detail: { fontSize: 14, color: '#666', marginBottom: 12 },
 });
 
 export default App;

--- a/__tests__/AppService.test.ts
+++ b/__tests__/AppService.test.ts
@@ -1,0 +1,34 @@
+import { Alert } from 'react-native';
+import { AppService } from '../src/AppService';
+import { AppStateManager } from '../src/AppState';
+import { IapticRN } from 'react-native-iaptic';
+
+describe('AppService checkFeatureAccess', () => {
+  let service: AppService;
+
+  beforeEach(() => {
+    const state = { applicationUsername: 'test', entitlements: [] };
+    const manager = new AppStateManager([state, jest.fn()]);
+    service = new AppService(manager);
+    jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('alerts unlocked message when entitlement present', () => {
+    (IapticRN.checkEntitlement as jest.Mock).mockReturnValue(true);
+    service.checkFeatureAccess('feat');
+    expect(IapticRN.checkEntitlement).toHaveBeenCalledWith('feat');
+    expect(Alert.alert).toHaveBeenCalledWith('"feat" feature is unlocked.');
+  });
+
+  it('alerts subscription prompt when locked', () => {
+    (IapticRN.checkEntitlement as jest.Mock).mockReturnValue(false);
+    service.checkFeatureAccess('feat');
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Please subscribe to the app to unlock feature "feat".'
+    );
+  });
+});

--- a/iap-webhook-tester/index.js
+++ b/iap-webhook-tester/index.js
@@ -5,6 +5,19 @@ app.use(express.json()); // parse JSON bodies
 app.post('/iap/webhook', (req, res) => {
   console.log('🔔 Webhook payload received:');
   console.dir(req.body, { depth: null, colors: true });
+  // Pseudo logic for subscription lifecycle events
+  const { type, applicationUsername, purchases } = req.body;
+  if (type === 'purchases.updated') {
+    Object.values(purchases || {}).forEach(purchase => {
+      if (!purchase.lastRenewalDate) {
+        console.log(`➡️  Subscription created for ${applicationUsername}: ${purchase.productId}`);
+      } else if (purchase.isExpired) {
+        console.log(`❌ Subscription expired/cancelled for ${applicationUsername}: ${purchase.productId}`);
+      } else {
+        console.log(`🔄 Subscription updated for ${applicationUsername}: ${purchase.productId}`);
+      }
+    });
+  }
   // respond 200 so Iaptic knows you got it
   res.sendStatus(200);
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,9 @@
 module.exports = {
   preset: 'react-native',
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native' +
+      '|@react-native' +
+      '|react-native-iaptic)/)',
+  ],
+  setupFiles: ['./jest.setup.js'],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,19 @@
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);
+
+jest.mock('react-native-iaptic', () => {
+  return {
+    IapticRN: {
+      addEventListener: jest.fn(),
+      initialize: jest.fn(),
+      setApplicationUsername: jest.fn(),
+      loadProducts: jest.fn(),
+      getProducts: jest.fn().mockReturnValue([]),
+      order: jest.fn(),
+      listEntitlements: jest.fn().mockReturnValue([]),
+      getActiveSubscription: jest.fn(),
+      checkEntitlement: jest.fn().mockReturnValue(false),
+    },
+  };
+});

--- a/src/AppState.ts
+++ b/src/AppState.ts
@@ -14,7 +14,7 @@ export interface AppState {
  * The initial state of the app
  */
 export const initialAppState: AppState = {
-  applicationUsername: 'iaptic-rn-demo-user',
+  applicationUsername: 'UseUserIdforTapynHere',
   entitlements: [],
 }
 

--- a/src/SubscriptionScreen.tsx
+++ b/src/SubscriptionScreen.tsx
@@ -85,8 +85,12 @@ export function SubscriptionScreen({ onClose }: { onClose: () => void }) {
                 )}
               </TouchableOpacity>
               <TouchableOpacity
-                style={[styles.button, { marginTop: 8 }]}
-                onPress={() => singletons.iapServiceInstance?.checkFeatureAccess(entitlements[0] || item.id)}
+                style={[styles.button, { marginTop: 8, backgroundColor: hasAccess ? 'green' : 'red' }]}
+                onPress={() =>
+                { singletons.iapServiceInstance?.checkFeatureAccess(entitlements[0] || item.id);
+                  console.log('it,.id', entitlements[0] || item.id);
+                 }
+                }
               >
                 <Text style={styles.buttonText}>
                   Access: {hasAccess ? 'Granted' : 'Locked'}

--- a/src/SubscriptionScreen.tsx
+++ b/src/SubscriptionScreen.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native';
+import { IapticRN, IapticProduct, IapticOffer } from 'react-native-iaptic';
+import { singletons } from './singletons';
+
+export function SubscriptionScreen({ onClose }: { onClose: () => void }) {
+  const [subscriptions, setSubscriptions] = useState<IapticProduct[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [purchasingId, setPurchasingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const myUserId = 'user_12345';
+        await IapticRN.setApplicationUsername(myUserId);
+        const all = IapticRN.getProducts();
+        const subs = all.filter(p => p.type === 'paid subscription' || 'consumable');
+        setSubscriptions(subs);
+      } catch (err) {
+        console.warn('Error loading subscription products:', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handlePurchase = async (offer: IapticOffer, productId: string) => {
+    try {
+      setPurchasingId(productId);
+      await IapticRN.order(offer);
+      singletons.iapServiceInstance?.handlePurchaseComplete();
+    } catch (err) {
+      console.warn('Purchase error:', err);
+    } finally {
+      setPurchasingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Text>Loading subscriptions…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.screenContainer}>
+      <TouchableOpacity onPress={onClose} style={styles.backButton}>
+        <Text style={styles.backText}>← Back</Text>
+      </TouchableOpacity>
+
+      <FlatList
+        data={subscriptions}
+        keyExtractor={item => item.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => {
+          const offer: IapticOffer = item.offers[0];
+          const entitlements = (item as any).entitlements || [];
+          const hasAccess = entitlements.some((e: string) =>
+            singletons.appStateManagerInstance?.getState().entitlements.includes(e),
+          );
+
+          return (
+            <View style={styles.card}>
+              <Text style={styles.title}>{item.title}</Text>
+              <Text style={styles.price}>{offer.localizedPrice || offer.pricingPhases[0].price}</Text>
+              <Text style={styles.detail}>{offer.pricingPhases[0].billingPeriod}</Text>
+              <TouchableOpacity
+                style={styles.button}
+                disabled={purchasingId === item.id}
+                onPress={() => handlePurchase(offer, item.id)}
+              >
+                {purchasingId === item.id ? (
+                  <ActivityIndicator color="#fff" />
+                ) : (
+                  <Text style={styles.buttonText}>Buy</Text>
+                )}
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.button, { marginTop: 8 }]}
+                onPress={() => singletons.iapServiceInstance?.checkFeatureAccess(entitlements[0] || item.id)}
+              >
+                <Text style={styles.buttonText}>
+                  Access: {hasAccess ? 'Granted' : 'Locked'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          );
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: { backgroundColor: '#007AFF', padding: 14, borderRadius: 8, alignItems: 'center' },
+  buttonText: { color: '#fff', fontSize: 16 },
+  screenContainer: { flex: 1, paddingTop: 40 },
+  backButton: { padding: 12 },
+  backText: { fontSize: 16, color: '#007AFF' },
+  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  list: { padding: 16 },
+  card: { backgroundColor: '#fff', borderRadius: 8, padding: 16, marginBottom: 12, shadowColor: '#000', shadowOpacity: 0.1, shadowRadius: 4 },
+  title: { fontSize: 18, fontWeight: 'bold' },
+  price: { fontSize: 16, marginVertical: 4 },
+  detail: { fontSize: 14, color: '#666', marginBottom: 12 },
+});
+

--- a/src/singletons.ts
+++ b/src/singletons.ts
@@ -1,0 +1,4 @@
+export const singletons = {
+  appStateManagerInstance: null as import('./AppState').AppStateManager | null,
+  iapServiceInstance: null as import('./AppService').AppService | null,
+};


### PR DESCRIPTION
## Summary
- move `SubscriptionScreen` component into its own file
- share IAP service instances via `src/singletons.ts`
- update `App.tsx` to use the external screen component
- add unit tests for `AppService.checkFeatureAccess`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b59904110832e94bd2713c4aea3d9